### PR TITLE
FEATURE: Support for overriding the batch size via CLI

### DIFF
--- a/Classes/Ttree/ContentRepositoryImporter/Aspect/EventLogAspect.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Aspect/EventLogAspect.php
@@ -76,7 +76,7 @@ class EventLogAspect
     public function flushEvents(JoinPointInterface $joinPoint)
     {
         try {
-            $this->importService->persisteEntities();
+            $this->importService->persistEntities();
             $this->nodeDataRepository->persistEntities();
         } catch (\Exception $exception) {
             $this->logger->logException($exception);

--- a/Classes/Ttree/ContentRepositoryImporter/Command/ImportCommandController.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Command/ImportCommandController.php
@@ -17,7 +17,6 @@ use TYPO3\Flow\Core\Booting\Scripts;
 use TYPO3\Flow\Exception;
 use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\Flow\Object\ObjectManagerInterface;
-use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Utility\Arrays;
 use TYPO3\Neos\EventLog\Domain\Service\EventEmittingService;
 
@@ -41,10 +40,10 @@ class ImportCommandController extends CommandController
     protected $eventLogRepository;
 
     /**
-     * @Flow\Inject
-     * @var ConfigurationManager
+     * @Flow\InjectConfiguration(package="TYPO3.Flow")
+     * @var array
      */
-    protected $configurationManager;
+    protected $flowSettings;
 
     /**
      * @Flow\Inject
@@ -102,23 +101,34 @@ class ImportCommandController extends CommandController
     }
 
     /**
-     * Batch process of the given preset
+     * Run batch import
      *
-     * @param string $preset
-     * @param string $parts
+     * This executes a batch import as configured in the settings for the specified preset. Optionally the "parts" can
+     * be specified, separated by comma ",".
+     *
+     * Presets and parts need to be configured via settings first. Refer to the documentation for possible options and
+     * example configurations.
+     *
+     * @param string $preset Name of the preset which holds the configuration for the import
+     * @param string $parts Optional comma separated names of parts. If no parts are specified, all parts will be imported.
+     * @param integer $batchSize Number of records to import at a time. If not specified, the batch size defined in the preset will be used.
+     * @return void
      */
-    public function batchCommand($preset, $parts = null)
+    public function batchCommand($preset, $parts = null, $batchSize = null)
     {
         $this->importService->start();
+
         $this->startTime = microtime(true);
         $parts = Arrays::trimExplode(',', $parts);
+
         $this->outputLine('Start import ...');
         $presetSettings = Arrays::getValueByPath($this->settings, array('presets', $preset));
         if (!is_array($presetSettings)) {
             $this->outputLine(sprintf('Preset "%s" not found ...', $preset));
             $this->quit(1);
         }
-        array_walk($presetSettings, function ($partSetting, $partName) use ($preset, $parts) {
+
+        array_walk($presetSettings, function ($partSetting, $partName) use ($preset, $parts, $batchSize) {
             $this->elapsedTime = 0;
             $this->batchCounter = 0;
             $this->outputLine();
@@ -126,6 +136,9 @@ class ImportCommandController extends CommandController
 
             $partSetting['__currentPresetName'] = $preset;
             $partSetting['__currentPartName'] = $partName;
+            if ($batchSize !== null) {
+                $partSetting['batchSize'] = $batchSize;
+            }
 
             $partSetting = new PresetPartDefinition($partSetting, $this->importService->getCurrentImportIdentifier());
             if ($parts !== array() && !in_array($partName, $parts)) {
@@ -143,6 +156,7 @@ class ImportCommandController extends CommandController
 
         $this->importService->stop();
         $import = $this->importService->getLastImport();
+
         $this->outputLine();
         $this->outputLine('Import finished');
         $this->outputLine(sprintf('  Started   %s', $import->getStart()->format(DATE_RFC2822)));
@@ -151,8 +165,10 @@ class ImportCommandController extends CommandController
     }
 
     /**
+     * Execute a sub process which imports a batch as specified by the part definition.
+     *
      * @param PresetPartDefinition $partSetting
-     * @return integer
+     * @return integer The number of records which have been imported
      */
     protected function executeCommand(PresetPartDefinition $partSetting)
     {
@@ -164,7 +180,7 @@ class ImportCommandController extends CommandController
 
             ++$this->batchCounter;
             ob_start();
-            $status = Scripts::executeCommand('ttree.contentrepositoryimporter:import:executebatch', $this->getFlowSettings(), true, $partSetting->getCommandArguments());
+            $status = Scripts::executeCommand('ttree.contentrepositoryimporter:import:executebatch', $this->flowSettings, true, $partSetting->getCommandArguments());
             if ($status !== true) {
                 throw new Exception('Sub command failed', 1426767159);
             }
@@ -188,6 +204,11 @@ class ImportCommandController extends CommandController
     }
 
     /**
+     * Import a single batch
+     *
+     * This internal command is called by executeCommand() and runs an isolated import for a batch as specified by
+     * the command's arguments.
+     *
      * @param string $presetName
      * @param string $partName
      * @param string $dataProviderClassName
@@ -195,7 +216,7 @@ class ImportCommandController extends CommandController
      * @param string $currentImportIdentifier
      * @param integer $offset
      * @param integer $batchSize
-     * @return integer
+     * @return void
      * @Flow\Internal
      */
     public function executeBatchCommand($presetName, $partName, $dataProviderClassName, $importerClassName, $currentImportIdentifier, $offset = null, $batchSize = null)
@@ -219,13 +240,5 @@ class ImportCommandController extends CommandController
             $this->logger->logException($exception);
             $this->quit(1);
         }
-    }
-
-    /**
-     * @return array
-     */
-    protected function getFlowSettings()
-    {
-        return $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
     }
 }

--- a/Classes/Ttree/ContentRepositoryImporter/Command/ImportCommandController.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Command/ImportCommandController.php
@@ -12,7 +12,6 @@ use Ttree\ContentRepositoryImporter\Domain\Service\ImportService;
 use Ttree\ContentRepositoryImporter\Importer\Importer;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
-use TYPO3\Flow\Configuration\ConfigurationManager;
 use TYPO3\Flow\Core\Booting\Scripts;
 use TYPO3\Flow\Exception;
 use TYPO3\Flow\Log\SystemLoggerInterface;
@@ -93,14 +92,6 @@ class ImportCommandController extends CommandController
     }
 
     /**
-     * Remove all import event from the event log
-     */
-    public function flushEventLogCommand()
-    {
-        $this->eventLogRepository->removeAll();
-    }
-
-    /**
      * Run batch import
      *
      * This executes a batch import as configured in the settings for the specified preset. Optionally the "parts" can
@@ -174,7 +165,7 @@ class ImportCommandController extends CommandController
     {
         try {
             $this->importService->addEvent(sprintf('%s:Started', $partSetting->getEventType()), null, $partSetting->getCommandArguments());
-            $this->importService->persisteEntities();
+            $this->importService->persistEntities();
 
             $startTime = microtime(true);
 
@@ -193,7 +184,7 @@ class ImportCommandController extends CommandController
             $this->elapsedTime += $elapsedTime;
             $this->outputLine('  #%d %d records in %dms, %d ms per record, %d ms per batch (avg)', [$partSetting->getCurrentBatch(), $count, $elapsedTime, $elapsedTime / $count, $this->elapsedTime / $this->batchCounter]);
             $this->importService->addEvent(sprintf('%s:Ended', $partSetting->getEventType()), null, $partSetting->getCommandArguments());
-            $this->importService->persisteEntities();
+            $this->importService->persistEntities();
             return $count;
         } catch (\Exception $exception) {
             $this->logger->logException($exception);
@@ -241,4 +232,17 @@ class ImportCommandController extends CommandController
             $this->quit(1);
         }
     }
+
+    /**
+     * Clean up event log
+     *
+     * This command removes all Neos event log entries caused by the importer.
+     *
+     * @return void
+     */
+    public function flushEventLogCommand()
+    {
+        $this->eventLogRepository->removeAll();
+    }
+
 }

--- a/Classes/Ttree/ContentRepositoryImporter/DataProvider/CsvDataProvider.php
+++ b/Classes/Ttree/ContentRepositoryImporter/DataProvider/CsvDataProvider.php
@@ -124,6 +124,7 @@ class CsvDataProvider implements DataProviderInterface
             fclose($handle);
         }
 
+        $this->logger->log(sprintf('%s: read %s lines and found %s records.', $this->csvFilePath, $currentLine, count($dataResult)), LOG_DEBUG);
         return $dataResult;
     }
 

--- a/Classes/Ttree/ContentRepositoryImporter/Domain/Service/ImportService.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Domain/Service/ImportService.php
@@ -158,7 +158,7 @@ class ImportService
     /**
      * Persist all pending entities
      */
-    public function persisteEntities()
+    public function persistEntities()
     {
         $this->importRepository->persistEntities();
     }

--- a/Classes/Ttree/ContentRepositoryImporter/Importer/Importer.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Importer/Importer.php
@@ -256,6 +256,15 @@ abstract class Importer implements ImporterInterface
     }
 
     /**
+     * Checks if processing / import of the record specified by $externalIdentifier should be skipped.
+     *
+     * The following criteria for skipping the processing exist:
+     *
+     * 1) a record with the given external identifier already has been processed in the past
+     * 2) a node with a node name equal to what a new node would have already exists
+     *
+     * These criteria can be enabled or disabled through $skipExistingNode and $skipAlreadyProcessed.
+     *
      * @param string $externalIdentifier
      * @param string $nodeName
      * @param NodeInterface $storageNode

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ You can also filter the preset steps:
 flow import:batch --preset base --parts page,pageContent
 ```
 
+For testing purposes, or if you would like to override the value definied in your preset, you can also specify the number
+of records which should be imported at a time in an isolated sub-process:
+
+```
+flow import:batch --preset base --batch-size 50
+```
+
 CSV Data Provider
 -----------------
 


### PR DESCRIPTION
This change introduces a new optional parameter for `import:batch`
which allows for specifying a different batch size than the one
defined in the import preset.
