### PR TITLE
FEATURE: Improve out-of-the-box capabilities of AbstractImporter

### DIFF
--- a/Classes/Ttree/ContentRepositoryImporter/DataProvider/AbstractDataProvider.php
+++ b/Classes/Ttree/ContentRepositoryImporter/DataProvider/AbstractDataProvider.php
@@ -34,7 +34,7 @@ abstract class AbstractDataProvider implements DataProviderInterface
      * @var integer
      * @api
      */
-    protected $offset;
+    protected $offset = 0;
 
     /**
      * @var integer

--- a/README.md
+++ b/README.md
@@ -55,7 +55,48 @@ class BasicDataProvider extends DataProvider {
 A basic Importer
 ----------------
 
-TODO
+```php
+class ProductImporter extends AbstractImporter
+{
+
+    /**
+     * @var string
+     */
+    protected $externalIdentifierDataKey = 'productNumber';
+
+    /**
+     * @var string
+     */
+    protected $labelDataKey = 'properties.name';
+
+    /**
+     * @var string
+     */
+    protected $nodeNamePrefix = 'product-';
+
+    /**
+     * @var string
+     */
+    protected $nodeTypeName = 'Acme.Demo:Product';
+
+    /**
+     * Starts batch processing all commands
+     *
+     * @return void
+     * @api
+     */
+    public function process()
+    {
+        $this->initializeStorageNode('shop/products', 'products', 'Products', 'products');
+        $this->initializeNodeTemplates();
+
+        $nodeTemplate = new NodeTemplate();
+        $this->processBatch($nodeTemplate);
+    }
+
+}
+
+```
 
 A basic preset
 --------------


### PR DESCRIPTION
This greatly enhances the AbstractImporter by adding several convenience
methods. For many importers which are simply importing records into one
type of nodes, it is now possible to get a concrete importer running with
a minimal set of properties.

See new example in README.md.
