### PR TITLE
FEATURE: External reference for imports

### DIFF
--- a/Classes/Ttree/ContentRepositoryImporter/DataProvider/AbstractDataProvider.php
+++ b/Classes/Ttree/ContentRepositoryImporter/DataProvider/AbstractDataProvider.php
@@ -34,7 +34,7 @@ abstract class AbstractDataProvider implements DataProviderInterface
      * @var integer
      * @api
      */
-    protected $offset;
+    protected $offset = 0;
 
     /**
      * @var integer

--- a/Classes/Ttree/ContentRepositoryImporter/Domain/Model/Import.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Domain/Model/Import.php
@@ -29,6 +29,12 @@ class Import
     protected $end;
 
     /**
+     * @var string
+     * @ORM\Column(length=255, nullable=true)
+     */
+    protected $externalImportIdentifier;
+
+    /**
      * @Flow\Inject
      * @var EventEmittingService
      */
@@ -51,6 +57,23 @@ class Import
         }
     }
 
+    /**
+     * Sets an (external) identifier which allows for detecting already imported data sets.
+     *
+     * @param string $externalImportIdentifier
+     */
+    public function setExternalImportIdentifier($externalImportIdentifier)
+    {
+        $this->externalImportIdentifier = $externalImportIdentifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExternalImportIdentifier()
+    {
+        return $this->externalImportIdentifier;
+    }
     /**
      * @param string $eventType
      * @param string $externalIdentifier

--- a/Classes/Ttree/ContentRepositoryImporter/Exception/ImportAlreadyExecutedException.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Exception/ImportAlreadyExecutedException.php
@@ -1,0 +1,16 @@
+<?php
+namespace Ttree\ContentRepositoryImporter\Exception;
+
+/*
+ * This script belongs to the Neos Flow package "Ttree.ContentRepositoryImporter".
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Exception;
+
+/**
+ * Import Already Executed Exception
+ */
+class ImportAlreadyExecutedException extends Exception
+{
+}

--- a/Classes/Ttree/ContentRepositoryImporter/Importer/AbstractCommandBasedImporter.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Importer/AbstractCommandBasedImporter.php
@@ -1,0 +1,51 @@
+<?php
+namespace Ttree\ContentRepositoryImporter\Importer;
+
+/*
+ * This script belongs to the Neos Flow package "Ttree.ContentRepositoryImporter".
+ */
+
+use Ttree\ContentRepositoryImporter\DataType\Slug;
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\TYPO3CR\Domain\Model\NodeTemplate;
+
+/**
+ * A base importer for data providers which deliver data as commands (create, delete, update, ...) instead of plain
+ * data records.
+ */
+abstract class AbstractCommandBasedImporter extends AbstractImporter
+{
+
+    /**
+     * Processes a single command
+     *
+     * Override this method if you need a different approach.
+     *
+     * @param NodeTemplate $nodeTemplate
+     * @param array $data
+     * @return void
+     * @throws \Exception
+     * @api
+     */
+    public function processRecord(NodeTemplate $nodeTemplate, array $data)
+    {
+        $this->unsetAllNodeTemplateProperties($nodeTemplate);
+
+        $externalIdentifier = $this->getExternalIdentifierFromRecordData($data);
+        if (!isset($data['uriPathSegment'])) {
+            $data['uriPathSegment'] = Slug::create($this->getLabelFromRecordData($data))->getValue();
+        }
+
+        if (!isset($data['mode'])) {
+            throw new \Exception(sprintf('Could not determine command mode from data record with external identifier %s. Please make sure that "mode" exists in that record.', $externalIdentifier), 1462985246103);
+        }
+
+        $commandMethodName = $data['mode'] . 'Command';
+        if (!method_exists($this, $commandMethodName)) {
+            throw new \Exception(sprintf('Could not find a command method "%s" in %s for processing record with external identifier %s.', $commandMethodName, get_class($this), $externalIdentifier), 1462985425892);
+        }
+
+        $this->$commandMethodName($externalIdentifier, $data);
+    }
+
+}

--- a/Classes/Ttree/ContentRepositoryImporter/Importer/AbstractCommandBasedImporter.php
+++ b/Classes/Ttree/ContentRepositoryImporter/Importer/AbstractCommandBasedImporter.php
@@ -36,6 +36,9 @@ abstract class AbstractCommandBasedImporter extends AbstractImporter
             $data['uriPathSegment'] = Slug::create($this->getLabelFromRecordData($data))->getValue();
         }
 
+        $this->nodeTemplate->setNodeType($this->nodeType);
+        $this->nodeTemplate->setName($this->renderNodeName($externalIdentifier));
+
         if (!isset($data['mode'])) {
             throw new \Exception(sprintf('Could not determine command mode from data record with external identifier %s. Please make sure that "mode" exists in that record.', $externalIdentifier), 1462985246103);
         }

--- a/Migrations/Mysql/Version20160523202439.php
+++ b/Migrations/Mysql/Version20160523202439.php
@@ -1,0 +1,41 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Introduce externalimportidentifier property to Import model
+ */
+class Version20160523202439 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription() {
+        return 'Introduce externalimportidentifier property to Import model';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('ALTER TABLE ttree_contentrepositoryimporter_domain_model_import ADD externalimportidentifier VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('ALTER TABLE ttree_contentrepositoryimporter_domain_model_import DROP externalimportidentifier');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,48 @@ class BasicDataProvider extends DataProvider {
 A basic Importer
 ----------------
 
-TODO
+```php
+class ProductImporter extends AbstractImporter
+{
+
+    /**
+     * @var string
+     */
+    protected $externalIdentifierDataKey = 'productNumber';
+
+    /**
+     * @var string
+     */
+    protected $labelDataKey = 'properties.name';
+
+    /**
+     * @var string
+     */
+    protected $nodeNamePrefix = 'product-';
+
+    /**
+     * @var string
+     */
+    protected $nodeTypeName = 'Acme.Demo:Product';
+
+    /**
+     * Starts batch processing all commands
+     *
+     * @return void
+     * @api
+     */
+    public function process()
+    {
+        $this->initializeStorageNode('shop/products', 'products', 'Products', 'products');
+        $this->initializeNodeTemplates();
+
+        $nodeTemplate = new NodeTemplate();
+        $this->processBatch($nodeTemplate);
+    }
+
+}
+
+```
 
 A basic preset
 --------------

--- a/README.md
+++ b/README.md
@@ -170,6 +170,121 @@ of records which should be imported at a time in an isolated sub-process:
 flow import:batch --preset base --batch-size 50
 ```
 
+Command based importers
+-----------------------
+
+Some data sources may consist of commands rather than data records. For example, a JSON file may contain `create`,
+`update` and `delete` instructions which reduce the guess-work on the importer's side, which records may be new,
+which should be updated and if the absence of a record means that the corresponding node should be deleted from
+the content repository.
+
+For these cases you can extend the `AbstractCommandBasedImporter`. If your data records contain a `mode` field, the
+importer will try to call a corresponding command method within the same class.
+
+Consider the following data source file as an example:
+
+```json
+[
+    {
+        "mode": "create",
+        "mpn": "1081251137",
+        "languageIdentifier": "de",
+        "properties": {
+            "label": "Coffee Machine",
+            "price": "220000",
+            "externalKey": "1081251137"
+        }
+    },
+    {
+        "mode": "delete",
+        "mpn": "591500202"
+    }
+]
+```
+
+A corresponding `ProductImporter` might look like this:
+
+```php
+/**
+ * Class ProductImporter
+ */
+class ProductImporter extends AbstractCommandBasedImporter
+{
+
+    /**
+     * @var string
+     */
+    protected $storageNodeNodePath = 'products';
+
+    /**
+     * @var string
+     */
+    protected $storageNodeTitle = 'Products';
+
+    /**
+     * @var string
+     */
+    protected $externalIdentifierDataKey = 'mpn';
+
+    /**
+     * @var string
+     */
+    protected $labelDataKey = 'properties.Label';
+
+    /**
+     * @var string
+     */
+    protected $nodeNamePrefix = 'product-';
+
+    /**
+     * @var string
+    */
+    protected $nodeTypeName = 'Acme.MyShop:Product';
+
+    /**
+     * Creates a new product
+     *
+     * @param string $externalIdentifier
+     * @param array $data
+     * @return void
+     */
+    protected function createCommand($externalIdentifier, array $data)
+    {
+        $this->applyProperties($data['properties'], $this->nodeTemplate);
+
+        $node = $this->storageNode->createNodeFromTemplate($this->nodeTemplate);
+        $this->registerNodeProcessing($node, $externalIdentifier);
+    }
+
+    /**
+     * Updates a product
+     *
+     * @param string $externalIdentifier
+     * @param array $data
+     * @return void
+     */
+    protected function updateCommand($externalIdentifier, array $data)
+    {
+        $this->applyProperties($data['properties'], $this->nodeTemplate);
+
+        $node = $this->storageNode->createNodeFromTemplate($this->nodeTemplate);
+        $this->registerNodeProcessing($node, $externalIdentifier);
+    }
+
+    /**
+     * Deletes a product
+     *
+     * @param string $externalIdentifier
+     * @param array $data
+     */
+    protected function deleteCommand($externalIdentifier, array $data)
+    {
+        // delete the product node
+    }
+}
+```
+
+
 CSV Data Provider
 -----------------
 


### PR DESCRIPTION
You may optionally specify an external import identifier when running
the import:batch command which will be stored as meta data with the
import run. This identifier is used for checking if an import of the
given data set (in general) has been executed earlier.

The external import identifier therefore does globally what the external
record identifier does on a per record basis.

If an external import identifier was specified and an import using that
identifier has been executed earlier, the import command will stop with
a corresponding message. You can force running such an import by
specifying the new --force flag.

Based on PR #14 
