### PR TITLE
TASK: Allow passing exceedingArguments to import:batch command

### DIFF
--- a/Classes/DataProvider/AbstractDataProvider.php
+++ b/Classes/DataProvider/AbstractDataProvider.php
@@ -69,6 +69,11 @@ abstract class AbstractDataProvider implements DataProviderInterface
     protected $partName;
 
     /**
+     * @var array
+     */
+    protected $exceedingArguments = [];
+
+    /**
      * @param array $options
      * @param Vault|null $vault
      * @api
@@ -88,13 +93,17 @@ abstract class AbstractDataProvider implements DataProviderInterface
      * @param array $options Options for the Data Provider
      * @param integer $offset Record offset where the import should start
      * @param integer $limit Maximum number of records which should be imported
+     * @param array $exceedingArguments Exceeding arguments of the command
      * @return DataProviderInterface
      */
-    public static function create(array $options = [], $offset = null, $limit = null): DataProviderInterface
+    public static function create(array $options = [], $offset = null, $limit = null, $exceedingArguments = null): DataProviderInterface
     {
         $dataProvider = new static($options, new Vault($options['__presetName']));
         $dataProvider->setOffset($offset);
         $dataProvider->setLimit($limit);
+        if ($exceedingArguments) {
+            $dataProvider->setExceedingArguments($exceedingArguments);
+        }
 
         return $dataProvider;
     }
@@ -127,6 +136,22 @@ abstract class AbstractDataProvider implements DataProviderInterface
     public function hasLimit()
     {
         return $this->limit > 0;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExceedingArguments()
+    {
+        return $this->exceedingArguments;
+    }
+
+    /**
+     * @param array $exceedingArguments
+     */
+    public function setExceedingArguments($exceedingArguments)
+    {
+        $this->exceedingArguments = $exceedingArguments;
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -260,6 +260,19 @@ of records which should be imported at a time in an isolated sub-process:
 flow import:batch --preset base --batch-size 50
 ```
 
+Passing exceeding arguments to the DataProvider
+-----------------------------------------------
+
+The import process supports passing unnamed exceeding arguments to the `DataProvider`. This can be useful if you e.g. want to
+allow importing only a single record
+
+```
+flow import:batch --preset base recordIdentifier:1234
+```
+
+Exceeding arguments will be available in the `DataProvider` through `$this->getExceedingArguments()`. You need to process
+this data yourself and apply it to your fetching logic.
+
 Command based importers
 -----------------------
 


### PR DESCRIPTION
Exceeding arguments are unnamed arguments that are made available in the
DataProvider. This allows you to pass some arguments at runtime instead of
by configuration.

This is inspired by the KickstartController of Neos.Kickstart:
https://github.com/neos/kickstart/blob/master/Classes/Command/KickstartCommandController.php#L226

You must handle exceeding arguments yourself in the DataProvider. You can
get them through $this->getExceedingArguments().