### PR TITLE
TASK: Add option to enable/disable creating event log entries for rec…

### DIFF
--- a/Classes/Aspect/EventLogAspect.php
+++ b/Classes/Aspect/EventLogAspect.php
@@ -42,6 +42,12 @@ class EventLogAspect
     protected $logger;
 
     /**
+     * @Flow\InjectConfiguration("eventLog.recordLogEnabled")
+     * @var boolean
+     */
+    protected $recordLogEnabled;
+
+    /**
      * Add record started event
      *
      * @Flow\Before("within(Ttree\ContentRepositoryImporter\Importer\ImporterInterface) && method(.*->processRecord())")
@@ -49,6 +55,9 @@ class EventLogAspect
      */
     public function addRecordStartedEvent(JoinPointInterface $joinPoint)
     {
+        if (!$this->recordLogEnabled) {
+            return;
+        }
         $data = $joinPoint->getMethodArgument('data');
         $externalIdentifier = Arrays::getValueByPath($data, '__externalIdentifier');
         $title = Arrays::getValueByPath($data, '__label');

--- a/Classes/Domain/Service/ImportService.php
+++ b/Classes/Domain/Service/ImportService.php
@@ -46,6 +46,12 @@ class ImportService
     protected $lastImport;
 
     /**
+     * @Flow\InjectConfiguration("eventLog.recordLogEnabled")
+     * @var boolean
+     */
+    protected $recordLogEnabled;
+
+    /**
      * @param string $identifier
      * @throws Exception
      */
@@ -124,13 +130,15 @@ class ImportService
         }
 
         $this->recordMappingRepository->persistEntities();
-        $this->addEvent(sprintf('%s:Record:Ended', substr($importerClassName, strrpos($importerClassName, '\\') + 1)), $externalIdentifier, [
-            'importerClassName' => $importerClassName,
-            'externalIdentifier' => $externalIdentifier,
-            'externalRelativeUri' => $externalRelativeUri,
-            'nodeIdentifier' => $nodeIdentifier,
-            'nodePath' => $nodePath
-        ]);
+        if ($this->recordLogEnabled) {
+            $this->addEvent(sprintf('%s:Record:Ended', substr($importerClassName, strrpos($importerClassName, '\\') + 1)), $externalIdentifier, [
+                'importerClassName' => $importerClassName,
+                'externalIdentifier' => $externalIdentifier,
+                'externalRelativeUri' => $externalRelativeUri,
+                'nodeIdentifier' => $nodeIdentifier,
+                'nodePath' => $nodePath
+            ]);
+        }
     }
 
     /**

--- a/Classes/Importer/AbstractImporter.php
+++ b/Classes/Importer/AbstractImporter.php
@@ -194,6 +194,12 @@ abstract class AbstractImporter implements ImporterInterface
     protected $settings;
 
     /**
+     * @Flow\InjectConfiguration("eventLog.recordLogEnabled")
+     * @var boolean
+     */
+    protected $recordLogEnabled;
+
+    /**
      * @var array
      */
     protected $options = [];
@@ -564,7 +570,9 @@ abstract class AbstractImporter implements ImporterInterface
         if (!isset($this->severityLabels[$severity])) {
             throw new Exception('Invalid severity value', 1426868867);
         }
-        $this->importService->addEventMessage(sprintf('Record:Import:Log:%s', $this->severityLabels[$severity]), $message, $severity, $this->currentEvent);
+        if ($this->recordLogEnabled) {
+            $this->importService->addEventMessage(sprintf('Record:Import:Log:%s', $this->severityLabels[$severity]), $message, $severity, $this->currentEvent);
+        }
     }
 
     /**

--- a/Classes/Service/NodePropertyMapper.php
+++ b/Classes/Service/NodePropertyMapper.php
@@ -20,6 +20,12 @@ class NodePropertyMapper
     protected $importService;
 
     /**
+     * @Flow\InjectConfiguration("eventLog.recordLogEnabled")
+     * @var boolean
+     */
+    protected $recordLogEnabled;
+
+    /**
      * Applies the given properties ($data) to the given Node or NodeTemplate
      *
      * @param array $data Property names and property values
@@ -27,7 +33,7 @@ class NodePropertyMapper
      * @param Event $currentEvent
      * @return bool True if an existing node has been modified, false if the new properties are the same like the old ones
      */
-    public function map(array $data, $nodeOrTemplate, Event $currentEvent)
+    public function map(array $data, $nodeOrTemplate, Event $currentEvent = null)
     {
         if (!$nodeOrTemplate instanceof NodeInterface && !$nodeOrTemplate instanceof NodeTemplate) {
             throw new \InvalidArgumentException(sprintf('$nodeOrTemplate must be either an object implementing NodeInterface or a NodeTemplate, %s given.', (is_object($nodeOrTemplate) ? get_class($nodeOrTemplate) : gettype($nodeOrTemplate))), 1462958554616);
@@ -49,7 +55,7 @@ class NodePropertyMapper
             $nodeOrTemplate->setIdentifier(trim($data['__identifier']));
         }
 
-        if ($nodeOrTemplate instanceof NodeInterface) {
+        if ($nodeOrTemplate instanceof NodeInterface && $this->recordLogEnabled) {
             $path = $nodeOrTemplate->getContextPath();
             if ($nodeChanged) {
                 $this->importService->addEventMessage('Node:Processed:Updated', sprintf('Updating existing node "%s" %s (%s)', $nodeOrTemplate->getLabel(), $path, $nodeOrTemplate->getIdentifier()), \LOG_INFO, $currentEvent);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -30,6 +30,9 @@ Ttree:
         postProcessing:
           '#^(?!.*?(?:<.*ul>|<.*li>|<.*ol>|<.*h.*>))(.+)$#uim': '<p>$1</p>'
 
+    eventLog:
+      recordLogEnabled: true
+
 #    presets:
 #      'base':
 #        parts:

--- a/README.md
+++ b/README.md
@@ -411,6 +411,22 @@ Ttree:
 ```
 
 
+Event log
+---------
+
+If the Neos Event Log is active, the importer adds log data for the import run and for each record processed. Three rows are created for each record processed. If you have a lot of data to process and/or do frequent imports, this will cause the event log to grow quickly.
+
+In that case, you might want to disable logging on a per-record basis by the following configuration:
+
+```yaml
+Ttree:
+  ContentRepositoryImporter:
+    eventLog:
+      recordLogEnabled: false
+```
+
+The importer will still add some general events to the log, such as the start and end of the whole import run and the preset/part currently processed.
+
 Acknowledgments
 ---------------
 


### PR DESCRIPTION
…ords

Currently, if the Neos Event Log is active, besides general information about
the import run or the preset/part currently processed, the importer writes
three records to the event log for each item imported. If you have a lot of
records and/or the import is running frequently, this will make the eventlog
table growing quickly.

In case you have sufficient logging without the event log, you might want to
disable logging on a per-record basis. This change adds a new setting without
changing the default functionality. Refer to the README for more information.